### PR TITLE
fix(table_manager): use `_document_type` instead of `type`

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: rubber-soul
-version: 1.14.4
+version: 1.15.0
 license: MIT
 
 authors:

--- a/spec/elastic_spec.cr
+++ b/spec/elastic_spec.cr
@@ -40,10 +40,10 @@ module RubberSoul
 
         # Ensure child is routed via parent in parent table
         parent_index_doc["_routing"].to_s.should eq child.programmer_id
-        parent_index_doc["_source"]["type"].should eq child_name
+        parent_index_doc["_source"]["_document_type"].should eq child_name
 
-        # Pick off "type" and "join" fields, convert to any for easy comparison
-        es_document = JSON.parse(parent_index_doc["_source"].as_h.reject("type", "join").to_json)
+        # Pick off "_document_type" and "join" fields, convert to any for easy comparison
+        es_document = JSON.parse(parent_index_doc["_source"].as_h.reject("_document_type", "join").to_json)
         local_document = JSON.parse(child.to_json)
 
         # Ensure document is the same across indices
@@ -146,10 +146,10 @@ module RubberSoul
 
           # Ensure child is routed via parent in parent table
           doc["_routing"].to_s.should eq model.id
-          doc["_source"]["type"].should eq model_name
+          doc["_source"]["_document_type"].should eq model_name
 
-          # Pick off "type" and "join" fields, convert to any for easy comparison
-          es_document = JSON.parse(doc["_source"].as_h.reject("type", "join").to_json)
+          # Pick off "_document_type" and "join" fields, convert to any for easy comparison
+          es_document = JSON.parse(doc["_source"].as_h.reject("_document_type", "join").to_json)
           local_document = JSON.parse(model.attributes.to_json)
 
           # Ensure local document is replicated in elasticsearch
@@ -212,10 +212,10 @@ module RubberSoul
 
         # Ensure child is routed via parent in parent table
         parent_index_doc["_routing"].to_s.should eq child.programmer_id
-        parent_index_doc["_source"]["type"].should eq child_name
+        parent_index_doc["_source"]["_document_type"].should eq child_name
 
-        # Pick off "type" and "join" fields, convert to any for easy comparison
-        es_document = JSON.parse(parent_index_doc["_source"].as_h.reject("type", "join").to_json)
+        # Pick off "_document_type" and "join" fields, convert to any for easy comparison
+        es_document = JSON.parse(parent_index_doc["_source"].as_h.reject("_document_type", "join").to_json)
         local_document = JSON.parse(child.to_json)
 
         # Ensure document is the same across indices
@@ -320,10 +320,10 @@ module RubberSoul
 
           # Ensure child is routed via parent in parent table
           doc["_routing"].to_s.should eq model.id
-          doc["_source"]["type"].should eq model_name
+          doc["_source"]["_document_type"].should eq model_name
 
-          # Pick off "type" and "join" fields, convert to any for easy comparison
-          es_document = JSON.parse(doc["_source"].as_h.reject("type", "join").to_json)
+          # Pick off "_document_type" and "join" fields, convert to any for easy comparison
+          es_document = JSON.parse(doc["_source"].as_h.reject("_document_type", "join").to_json)
           local_document = JSON.parse(model.attributes.to_json)
 
           # Ensure local document is replicated in elasticsearch

--- a/src/rubber-soul/elastic.cr
+++ b/src/rubber-soul/elastic.cr
@@ -485,7 +485,7 @@ module RubberSoul
     #
     private def self.document_body(document : Hash(String, JSON::Any), document_type, parent_id = nil, no_children = true)
       attributes = {} of String => String | NamedTuple(name: String, parent: String)
-      attributes["type"] = document_type
+      attributes["_document_type"] = document_type
 
       # Don't set a join field if there are no children on the index
       attributes["join"] = self.document_join_field(document_type, parent_id) unless no_children

--- a/src/rubber-soul/table_manager.cr
+++ b/src/rubber-soul/table_manager.cr
@@ -497,7 +497,7 @@ module RubberSoul
     end
 
     # Allows several document types beneath a single index
-    TYPE_PROPERTY = {:type, {type: "keyword"}}
+    TYPE_PROPERTY = {:_document_type, {type: "keyword"}}
 
     # Valid elasticsearch field datatypes
     private ES_TYPES = {


### PR DESCRIPTION
Rename `type` to `_document_type` as usage of `type` for a document field is reserved.