### PR TITLE
fix: ignore unmapped relations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,9 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile.test
+    volumes:
+      - ./spec:/app/spec
+      - ./src:/app/src
     hostname: rubber-soul
     depends_on:
       - elastic

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,6 @@ crystal tool format --check
 echo '### `ameba`'
 crystal lib/ameba/bin/ameba.cr
 
-
 watch="false"
 multithreaded="false"
 while [[ $# -gt 0 ]]

--- a/shard.lock
+++ b/shard.lock
@@ -66,7 +66,7 @@ shards:
 
   placeos-models:
     git: https://github.com/placeos/models.git
-    version: 4.7.0
+    version: 4.7.1
 
   promise:
     git: https://github.com/spider-gazelle/promise.git

--- a/src/config.cr
+++ b/src/config.cr
@@ -8,6 +8,7 @@ RubberSoul::MANAGED_TABLES = [
   PlaceOS::Model::ControlSystem,
   PlaceOS::Model::DoorkeeperApplication,
   PlaceOS::Model::Driver,
+  PlaceOS::Model::Edge,
   PlaceOS::Model::LdapAuthentication,
   PlaceOS::Model::Module,
   PlaceOS::Model::OAuthAuthentication,

--- a/src/rubber-soul/table_manager.cr
+++ b/src/rubber-soul/table_manager.cr
@@ -583,7 +583,7 @@ module RubberSoul
           options = attr_data[:tags]
           !!(options && options[:parent]?.try { |p| p == document_name })
         end
-        name if is_child
+        name if is_child && MODEL_METADATA.has_key?(name)
       end
     end
 


### PR DESCRIPTION
Adds a check to ensure relations mapped before generating a mapping for them.
Also adds `Edge` model to the config for rubber-soul 