### PR TITLE
fix: deadlock backfill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
       matrix:
         crystal:
           - 1.1.0
-          - 1.0.0
         stable: [true]
         include:
           - crystal: nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
     strategy:
       matrix:
         crystal:
+          - 1.1.0
           - 1.0.0
         stable: [true]
         include:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG crystal_version=1.0.0
+ARG crystal_version=1.1.0
 FROM crystallang/crystal:${crystal_version}-alpine
 
 # Setup commit via a build arg

--- a/shard.lock
+++ b/shard.lock
@@ -51,7 +51,7 @@ shards:
 
   lucky_router:
     git: https://github.com/luckyframework/lucky_router.git
-    version: 0.4.2
+    version: 0.5.0
 
   neuroplastic:
     git: https://github.com/spider-gazelle/neuroplastic.git
@@ -67,7 +67,7 @@ shards:
 
   placeos-models:
     git: https://github.com/placeos/models.git
-    version: 5.7.4
+    version: 5.7.5
 
   promise:
     git: https://github.com/spider-gazelle/promise.git

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: rubber-soul
-version: 1.19.6
+version: 1.19.7
 crystal: ">= 1.0.0"
 license: MIT
 authors:

--- a/src/app.cr
+++ b/src/app.cr
@@ -164,15 +164,16 @@ else
   # Docker containers use the term signal
   Signal::TERM.trap &terminate
 
+  Log.info { "Launching #{RubberSoul::APP_NAME} v#{RubberSoul::VERSION}" }
+  Log.info { "With RethinkDB \"#{rethink_db}\" on #{RethinkORM::Connection.settings.host}:#{RethinkORM::Connection.settings.port}" }
+  Log.info { "With Elasticsearch on #{RubberSoul::Elastic.settings.host}:#{RubberSoul::Elastic.settings.port}" }
+  Log.info { "Mirroring #{RubberSoul::MANAGED_TABLES.map(&.name).sort!.join(", ")}" }
+
   # Start API's TableManager instance
   RubberSoul::Api.table_manager
 
   # Start the server
   server.run do
-    Log.info { "Launching #{RubberSoul::APP_NAME} v#{RubberSoul::VERSION}" }
-    Log.info { "With RethinkDB \"#{rethink_db}\" on #{RethinkORM::Connection.settings.host}:#{RethinkORM::Connection.settings.port}" }
-    Log.info { "With Elasticsearch on #{RubberSoul::Elastic.settings.host}:#{RubberSoul::Elastic.settings.port}" }
-    Log.info { "Mirroring #{RubberSoul::MANAGED_TABLES.map(&.name).sort!.join(", ")}" }
     Log.info { "Listening on #{server.print_addresses}" }
   end
 end


### PR DESCRIPTION
- Switch to a single request backfill to use a big batch of futures (backpressure provided by access to the pool of elastic clients)
- Update crystal to 1.1.0
- Print app info before printing that the server is starting