### PR TITLE
fix(constants): revert `ES_DISABLE_BULK` to previous behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,30 +37,34 @@ Healthcheck.
 
 ## Configuration
 
-- `ENV`: a value of `production` lowers log verbosity
-- `ES_HOST`: elasticsearch host
-- `ES_PORT`: elasticsearch port
-- `ES_TLS`: use elasticsearch https, default is `false`
-- `ES_URI`: elasticsearch uri, detects whether to use TLS off schema
-- `RUBBER_SOUL_HOST`: host to bind server to
-- `RUBBER_SOUL_PORT`: port for server to listen on
-- `LOGSTASH_HOST`: Logstash host for sending JSON formatted logs to
-- `LOGSTASH_PORT`: Logstash port that UDP input service is listening on
+- `ENV`: A value of `production` lowers log verbosity
+- `ES_HOST`: Elasticsearch host
+- `ES_PORT`: Elasticsearch port
+- `ES_TLS`: Use Elasticsearch https, default is `false`
+- `ES_URI`: Elasticsearch uri, detects whether to use TLS off schema
+- `ES_DISABLE_BULK`: Use single requests to Elasticsearch instead of the bulk API. Defaults to `false`
+- `ES_CONN_POOL_TIMEOUT`: Timeout when checking a connection out of the Elasticsearch connection pool
+- `ES_CONN_POOL`: Size of the Elasticsearch connection pool
+- `ES_IDLE_POOL`: Maximum number of idle connections in the Elasticsearch connection pool
+- `UDP_LOG_HOST`: Host for sending JSON formatted logs to
+- `UDP_LOG_PORT`: Port that UDP input service is listening on
+- `RETHINKDB_DB`: DB to mirror to Elasticsearch, defaults to `"test"`
+- `RETHINKDB_HOST`: Host of RethinkDB, defaults to `localhost`
+- `RETHINKDB_PORT`: Port of RethinkDB, defaults to `28015`
+- `RUBBER_SOUL_HOST`: Host to bind server to
+- `RUBBER_SOUL_PORT`: Port for server to listen on
 
 ## Development
 
 Tested against...
 
-- rethinkdb 2.3.6
-- elasticsearch 7.0.0
+- RethinkDB 2.4.0
+- Elasticsearch 7.6.2
 
-## Contributing
+### Environment
 
-1. [Fork it](https://github.com/aca-labs/rubber-soul/fork)
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create a new Pull Request
+- `$ ./test` (run tests and tear down the test environment on exit)
+- `$ ./test --watch` (run test suite on change)
 
 ## Contributors
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: rubber-soul
-version: 1.19.9
+version: 1.19.10
 crystal: ">= 1.0.0"
 license: MIT
 authors:

--- a/src/constants.cr
+++ b/src/constants.cr
@@ -1,4 +1,5 @@
 require "action-controller/logger"
+
 require "secrets-env"
 
 module RubberSoul
@@ -9,35 +10,9 @@ module RubberSoul
   BUILD_TIME   = {{ system("date -u").stringify }}
   BUILD_COMMIT = {{ env("PLACE_COMMIT") || "DEV" }}
 
-  Log           = ::Log.for(self)
-  LOG_STDOUT    = ActionController.default_backend
-  LOGSTASH_HOST = ENV["LOGSTASH_HOST"]?.presence
-  LOGSTASH_PORT = ENV["LOGSTASH_PORT"]?.presence
+  Log = ::Log.for(self)
 
   RETHINK_DATABASE = ENV["RETHINKDB_DB"]? || "test"
-
-  def self.log_backend
-    if !(logstash_host = LOGSTASH_HOST.presence).nil?
-      logstash_port = LOGSTASH_PORT.try(&.to_i?) || abort("LOGSTASH_PORT is either malformed or not present in environment")
-
-      # Logstash UDP Input
-      logstash = UDPSocket.new
-      logstash.connect logstash_host, logstash_port
-      logstash.sync = false
-
-      # debug at the broadcast backend level, however this will be filtered
-      # by the bindings
-      backend = ::Log::BroadcastBackend.new
-      backend.append(LOG_STDOUT, :trace)
-      backend.append(ActionController.default_backend(
-        io: logstash,
-        formatter: ActionController.json_formatter
-      ), :trace)
-      backend
-    else
-      LOG_STDOUT
-    end
-  end
 
   class_getter? production : Bool = (ENV["ENV"]? || ENV["SG_ENV"]?).try(&.downcase) == "production"
 

--- a/src/constants.cr
+++ b/src/constants.cr
@@ -46,7 +46,7 @@ module RubberSoul
   PORT = ENV["RUBBER_SOUL_PORT"]?.presence.try(&.to_i) || 3000
 
   # ES config used in `./rubber-soul/elastic.cr`
-  ES_DISABLE_BULK      = ENV.has_key?("ES_DISABLE_BULK") ? ENV["ES_DISABLE_BULK"] == "true" : true
+  ES_DISABLE_BULK      = !!(ENV["ES_DISABLE_BULK"]?.presence.try &.downcase.in?("1", "true"))
   ES_URI               = ENV["ES_URI"]?.try(&->URI.parse(String))
   ES_HOST              = ENV["ES_HOST"]? || "localhost"
   ES_PORT              = ENV["ES_PORT"]?.try(&.to_i) || 9200


### PR DESCRIPTION
`ES_DISABLE_BULK` was defaulting to `true`, disabling the bulk API.
Previously, the bulk API was used by default without issue.

This PR reverts to using the bulk API by default.

Closes #40 